### PR TITLE
Show failures from before/after hooks

### DIFF
--- a/lib/html-reporter/components/test-failures.js
+++ b/lib/html-reporter/components/test-failures.js
@@ -41,12 +41,24 @@ export default class TestFailures {
         <div className='root'>
           <span className='header'>{suite.title}</span>
           <div className='tests-container'>
-            {this.renderTestFailures(suite.tests)}
-            {suite.suites.map(this.renderSubSuite.bind(this))}
+            {this.renderSuiteFailures(suite)}
           </div>
         </div>
       )
     }
+  }
+
+  renderSuiteFailures (suite) {
+    return (
+      <div>
+        {this.renderTestFailures(suite._beforeAll)}
+        {this.renderTestFailures(suite._beforeEach)}
+        {this.renderTestFailures(suite._afterEach)}
+        {this.renderTestFailures(suite._afterAll)}
+        {this.renderTestFailures(suite.tests)}
+        {suite.suites.map(this.renderSubSuite.bind(this))}
+      </div>
+    )
   }
 
   renderTestFailures (tests) {
@@ -73,8 +85,7 @@ export default class TestFailures {
         <div className='tests-container'>
           <span>{suite.title}</span>
           <div className='tests-container'>
-            {this.renderTestFailures(suite.tests)}
-            {suite.suites.map(this.renderSubSuite.bind(this))}
+            {this.renderSuiteFailures(suite)}
           </div>
         </div>
       )


### PR DESCRIPTION
Fixes #2 

![atom-mocha-test-runner_tests](https://cloud.githubusercontent.com/assets/189606/16672378/a3573efe-445a-11e6-8b71-0f209f6b309c.png)
