### PR TITLE
Improve for running specific test files

### DIFF
--- a/lib/create-runner.js
+++ b/lib/create-runner.js
@@ -78,7 +78,11 @@ export default function createRunner (options = {}, callback) {
       }
 
       for (let path of testPaths) {
-        for (let resolvedFile of utils.lookupFiles(path, options.testSuffixes, true)) {
+        let resolvedFiles = utils.lookupFiles(path, options.testSuffixes, true);
+        if (typeof resolvedFiles === "string") {
+          resolvedFiles = [resolvedFiles];
+        }
+        for (let resolvedFile of resolvedFiles) {
           delete require.cache[resolvedFile]
           mocha.addFile(resolvedFile)
         }


### PR DESCRIPTION
hello, i noticed i can't run specific test files,
such as 

``` sh
atom --test test/main.test.js test/view.test.js
```

output

```
Error: Cannot find module '/'
```

it seems that `Mocha.utils.lookupFiles()` may return string.
this pr will fix it so please check
