### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "author": "Michelle Tilley <michelle@michelletilley.net>",
   "license": "MIT",
   "dependencies": {
-    "etch": "^0.6.0",
+    "etch": "^0.8.0",
     "grim": "^2.0.1",
     "less": "^2.7.1",
-    "mocha": "^2.4.5",
-    "tmp": "0.0.28"
+    "mocha": "^3.0.0",
+    "tmp": "0.0.31"
   },
   "devDependencies": {
     "chai": "^3.5.0"


### PR DESCRIPTION
This updates a few dependencies, including bumping Mocha to 3.0. This gives us some new features:

* `.only` works as you think it should (e.g. setting `.only` on multiple tests runs all tests) /cc @kuychaco 
* `this.skip()` works in async test

And some things to be aware of:

* No longer works on Node v0.8 or npm <1.4.0