### PR TITLE
Add new runner option: `removeAtomStyle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Returns a test runner created with the given `options` and `callback`. Both para
   * `testSuffixes [default: ['test.js', 'test.coffee']]` - File extensions that indicate that the file contains tests
   * `colors [default: true (false on Windows)]` - Whether or not to colorize output on the terminal
   * `htmlTitle [default: '']` - The string to use for the window title in the HTML reporter
+  * `htmlRemoveAtomStyle [default: true]` - Whether to remove atom-style(which define basic style of editor, pane etc..) in html-test.
 
 ### Making Assertions
 

--- a/lib/create-runner.js
+++ b/lib/create-runner.js
@@ -4,6 +4,7 @@ import Grim from 'grim'
 
 const defaults = {
   htmlTitle: '',
+  htmlRemoveAtomStyle: true,
   reporter: 'dot',
   globalAtom: true,
   testSuffixes: ['test.js', 'test.coffee'],
@@ -63,6 +64,7 @@ export default function createRunner (options = {}, callback) {
         process.on('uncaughtException', console.error.bind(console))
         mocha.reporter(require('./html-reporter/html-reporter'), {
           title: options.htmlTitle,
+          removeAtomStyle: options.htmlRemoveAtomStyle,
           rerun: function () {
             runTests(testPaths, resolve)
           }

--- a/lib/html-reporter/html-reporter.js
+++ b/lib/html-reporter/html-reporter.js
@@ -98,6 +98,7 @@ module.exports = class AtomHtmlReporter {
   render () {
     const props = {
       title: this.options.title || "Atom Test Runner",
+      removeAtomStyle: this.options.removeAtomStyle,
       testTitle: this.currentTestTitle,
       runner: this.runner,
       rootSuite: this.rootSuite,
@@ -144,8 +145,10 @@ module.exports = class AtomHtmlReporter {
       configurable: true
     })
 
-    const atomStylesTag = document.querySelector('atom-styles')
-    if (atomStylesTag) atomStylesTag.remove()
+    if (props.removeAtomStyle) {
+      const atomStylesTag = document.querySelector('atom-styles')
+      if (atomStylesTag) atomStylesTag.remove()
+    }
 
     this.addElement(document.head, 'link', {
       'rel': 'stylesheet/less',


### PR DESCRIPTION
In following GIF, I need to set this new option to `false`(means don't remove `atom-style` tag) to make all test-pass.

![remove-atom-style](https://user-images.githubusercontent.com/155205/37166962-e191cc56-2343-11e8-9b1c-f9236e94553b.gif)


Add new `htmlRemoveAtomStyle` runner option.

- default `true`(compatible with current behavior).
- when set to `false` avoid removing `atom-style` tag in html-test.


But I think **default `false` is better for most user**, how do you think?
They use this runner to test atom-package, most user is possibly migrated from default jasmine runner.
This default behavioral change one of the biggest diff.

## Usage

- in `runner.js`

```javascript
module.exports = createRunner({
  htmlRemoveAtomStyle: false
})
```



## Why?

Removing `atom-tag` in web-test(`window:run-package-specs`) make `editor.element.component.isVisible()` always return `true` even though attaching `workspace.element` to DOM.
Which makes some view related test impossible.
So I need option to keep original `atom-style` style.

For a couple of days, I've been working to [migrate my pkg's test runner](https://github.com/t9md/atom-narrow/pull/292).
Most goes well, but I noticed
- Some test fail only in web-test `window:run-package-specs` case.
- No fail in headless run by `atom -t test`.
- I investigated and find out that `editor.element.component.isVisible()` always return `false` in web-test, which was caused by removal of `atom-style` style.
