### PR TITLE
Terminate the test suite within the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ var extraOptions = {
   testSuffixes: ['-spec.js', '-spec.coffee']
 }
 
-var optionalConfigurationFunction = function (mocha) {
+var optionalConfigurationFunction = function (mocha, {terminate}) {
   // If provided, atom-mocha-test-runner will pass the mocha instance
   // to this function, so you can do whatever you'd like to it.
+
+  // The "terminate" function may be called to prevent the test suite from running. If it's called with an argument,
+  // that will be used as the exit status of the main process.
 }
 
 module.exports = createRunner(extraOptions, optionalConfigurationFunction)

--- a/lib/create-runner.js
+++ b/lib/create-runner.js
@@ -80,7 +80,7 @@ export default function createRunner (options = {}, callback) {
         }
       }
 
-      if (callback) callback(mocha)
+      if (callback) callback(mocha, {terminate: resolve})
       Grim.clearDeprecations()
       const runner = mocha.run(resolve)
       window.runner = runner

--- a/test/runner.js
+++ b/test/runner.js
@@ -5,4 +5,9 @@ import {createRunner} from '../'
 module.exports = createRunner({
   globalAtom: false,
   htmlTitle: "atom-mocha-test-runner tests"
+}, (mocha, {terminate}) => {
+  if (process.env.ATOM_MOCHA_TERMINATE === 'true') {
+    console.log('Terminating test suite as requested.')
+    terminate()
+  }
 })


### PR DESCRIPTION
In atom/github#1664, I'm trying to prevent our test suite from running when the version range specified in the `engines` field of our `package.json` doesn't include the version of the host Atom process, so that we can bump the required Atom version without breaking our stable and beta test channels. This is the cleanest way I can think of to stop the test suite from running after `buildAtomEnvironment()` is available to query for the current version and exit with a 0 status.