### PR TITLE
New option for customizing `testPaths`

### DIFF
--- a/lib/create-runner.js
+++ b/lib/create-runner.js
@@ -7,7 +7,8 @@ const defaults = {
   reporter: 'dot',
   globalAtom: true,
   testSuffixes: ['test.js', 'test.coffee'],
-  colors: process.platform !== 'win32'
+  colors: process.platform !== 'win32',
+  transformTestPaths: (paths) => paths
 }
 
 export default function createRunner (options = {}, callback) {
@@ -95,7 +96,7 @@ export default function createRunner (options = {}, callback) {
           delete process.env.MOCHA_COLORS
         }
 
-        runTests(testPaths, resolve)
+        runTests(options.transformTestPaths(testPaths), resolve)
       } catch (ex) {
         console.error(ex.stack)
         resolve(1)


### PR DESCRIPTION
This commit adds a new option `transformTestPaths: [FilePath] -> [FilePath]` to `createRunner`,
which allows users to map the origin given paths `["./spec"]` to whatever paths they want.

This is particularly useful when you need to put your test in places other than  `./spec/`